### PR TITLE
refactor: align tmux config management with neovim pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ When it finishes, Bootler will print the "next steps" and a URL to test:
 | `NVIM_INSTALL_METHOD` | `appimage` | Installation method for Neovim (currently only `appimage`). |
 | `TMUX_PLUGIN_MANAGER_PATH` | `$HOME/.tmux/plugins` | Path for TMUX Plugin Manager (TPM) installation. |
 | `TMUX_INSTALL_TPM` | `1` | Install TMUX Plugin Manager (set to `0` to skip). |
-| `TMUX_MINIMAL_CONFIG` | `1` | Install minimal TMUX configuration if none exists (set to `0` to skip). |
 | `DOTFILES_REPO` | _(unset)_ | Optional URL of dotfiles repository to clone and apply. |
 | `DOTFILES_METHOD` | `stow` | Method to apply dotfiles: `stow` (symlinks) or `copy` (direct copy). |
 | `DOTFILES_PACKAGES` | _(unset)_ | Space-separated list of packages for stow method. |

--- a/bootler.sh
+++ b/bootler.sh
@@ -374,16 +374,13 @@ install_tmux() {
     fi
   fi
   
-  success "TMUX setup completed (TPM installed, configuration will be provided by dotfiles)"
-}
-
-# Install minimal tmux config as fallback if dotfiles don't provide one
-install_tmux_fallback_config() {
-  # Only install fallback if no tmux config exists and no dotfiles repo is configured
-  if [[ -z "${DOTFILES_REPO:-}" ]] && [[ ! -f "$TARGET_HOME/.tmux.conf" ]] && [[ ! -f "$TARGET_HOME/.config/tmux/tmux.conf" ]]; then
-    log "Installing minimal TMUX fallback configuration (no dotfiles configured)"
-    run_as "mkdir -p ~/.config/tmux"
-    run_as "cat > ~/.config/tmux/tmux.conf" <<'TMUX'
+  # Install minimal config (will be overwritten by dotfiles if present)
+  install -d -m 700 "$TARGET_HOME/.config"
+  chown -R "$TARGET_USER:$TARGET_USER" "$TARGET_HOME/.config"
+  
+  log "Installing minimal TMUX configuration"
+  run_as "mkdir -p ~/.config/tmux"
+  run_as "cat > ~/.config/tmux/tmux.conf" <<'TMUX'
 # Basic settings
 set -g mouse on
 set -g history-limit 10000
@@ -407,13 +404,12 @@ set -g @plugin 'tmux-plugins/tmux-sensible'
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'
 TMUX
-    # Create symlink for backward compatibility
-    run_as "ln -sf ~/.config/tmux/tmux.conf ~/.tmux.conf"
-    success "Minimal TMUX fallback configuration installed"
-  else
-    log "TMUX configuration exists or will be provided by dotfiles; skipping fallback"
-  fi
+  
+  # Create symlink for backward compatibility
+  run_as "ln -sf ~/.config/tmux/tmux.conf ~/.tmux.conf"
+  success "Minimal TMUX configuration installed"
 }
+
 
 
 # -------------------------- Security & Auth ---------------------------------
@@ -766,7 +762,6 @@ main() {
   install_neovim
   install_tmux
   setup_dotfiles
-  install_tmux_fallback_config
   install_additional_tools
   install_git_lfs
 


### PR DESCRIPTION
- Consolidate tmux configuration into install_tmux() function
- Always install minimal config (will be overwritten by dotfiles)
- Remove install_tmux_fallback_config() function and its conditional logic
- Remove TMUX_MINIMAL_CONFIG environment variable (no longer needed)
- Simplify main execution flow by removing fallback config call
- Maintain backward compatibility with ~/.tmux.conf symlink

This change makes tmux config management consistent with neovim:
- Both tools install minimal configs that dotfiles can override
- Eliminates complex conditional logic for fallback configurations
- Ensures users always have working configurations out of the box

🤖 Generated with [Claude Code](https://claude.ai/code)